### PR TITLE
libqasm

### DIFF
--- a/recipes/libqasm/all/conanfile.py
+++ b/recipes/libqasm/all/conanfile.py
@@ -1,10 +1,9 @@
-from conan import ConanFile, tools
+from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
 from conan.tools.scm import Git
 
 class LibqasmConan(ConanFile):
     name = "libqasm"
-    version = "0.5.0"
 
     # Optional metadata
     license = "Apache-2.0"

--- a/recipes/libqasm/all/conanfile.py
+++ b/recipes/libqasm/all/conanfile.py
@@ -44,7 +44,7 @@ class LibqasmConan(ConanFile):
             del self.options.fPIC
 
     def layout(self):
-        cmake_layout(self)
+        cmake_layout(self, src_folder="src")
 
     def source(self):
         git = Git(self)

--- a/recipes/libqasm/all/conanfile.py
+++ b/recipes/libqasm/all/conanfile.py
@@ -1,0 +1,75 @@
+from conan import ConanFile, tools
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
+from conan.tools.scm import Git
+
+class LibqasmConan(ConanFile):
+    name = "libqasm"
+    version = "0.5.0"
+
+    # Optional metadata
+    license = "Apache-2.0"
+    author = "QuTech-Delft"
+    url = "https://center.conan.io"
+    description = "Library to parse cQASM files"
+    topics = ("code generation", "parser", "compiler", "quantum compilation", "quantum simulation")
+
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "build_python": [True, False],
+        "build_tests": [True, False],
+        "compat": [True, False],
+        "tree_gen_build_tests": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "build_python": False,
+        "build_tests": False,
+        "compat": False,
+        "tree_gen_build_tests": False
+    }
+
+    def build_requirements(self):
+        self.tool_requires("m4/1.4.19")
+        if self.settings.os == "Windows":
+            self.tool_requires("winflexbison/2.5.24")
+        else:
+            self.tool_requires("flex/2.6.4")
+            self.tool_requires("bison/3.8.2")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def layout(self):
+        cmake_layout(self)
+
+    def source(self):
+        git = Git(self)
+        git.clone(url="https://github.com/QuTech-Delft/libqasm.git", target=".")
+        git.checkout("2db9916f8e32c5e36d05cb20cafb87133d4dbf16")
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.variables["LIBQASM_BUILD_PYTHON"] = self.options.build_python
+        tc.variables["LIBQASM_BUILD_TESTS"] = self.options.build_tests
+        tc.variables["LIBQASM_COMPAT"] = self.options.compat
+        tc.variables["TREE_GEN_BUILD_TESTS"] = self.options.tree_gen_build_tests
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["cqasm"]

--- a/recipes/libqasm/all/test_package/CMakeLists.txt
+++ b/recipes/libqasm/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(PackageTest CXX)
+
+find_package(libqasm CONFIG REQUIRED)
+
+add_executable(example src/example.cpp)
+target_link_libraries(example libqasm::libqasm)

--- a/recipes/libqasm/all/test_package/conanfile.py
+++ b/recipes/libqasm/all/test_package/conanfile.py
@@ -1,0 +1,30 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import cross_building
+
+
+class LibqasmTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    # VirtualBuildEnv and VirtualRunEnv can be avoided if "tools.env.virtualenv:auto_use" is defined
+    # (it will be defined in Conan 2.0)
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv", "VirtualRunEnv"
+    apply_env = False
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if not cross_building(self):
+            cmd = os.path.join(self.cpp.build.bindirs[0], "example")
+            self.run(cmd, env="conanrun")

--- a/recipes/libqasm/all/test_package/src/example.cpp
+++ b/recipes/libqasm/all/test_package/src/example.cpp
@@ -1,0 +1,5 @@
+#include "test_libqasm_conan_package.hpp"
+
+int main() {
+    test_libqasm_conan_package();
+}

--- a/recipes/libqasm/config.yml
+++ b/recipes/libqasm/config.yml
@@ -1,0 +1,4 @@
+versions:
+  # Newer versions at the top
+  "0.5.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libqasm/0.5**

libqasm is a library for handling cQASM files using C++ or Python (https://github.com/QuTech-Delft/libqasm, https://libqasm.readthedocs.io/en/latest/).
It is used by OpenQL, a framework for high-level quantum programming in C++/Python (https://github.com/QuTech-Delft/OpenQL, https://openql.readthedocs.io/en/latest/).
Both libqasm and OpenQL are developed by QuTech-Delft (TU Delft), for which I work as a software engineer.
It is a new addition to ConanCenter.
I basically want OpenQL users to be able to use libqasm in a simple way (i.e. without needing to install libqasm's dependencies manually).

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
      I've used conan 2.0.4.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
      I've tried building both in Linux and Windows in release and debug modes. These are the commands I use in each platform:
      conan create all/conanfile.py --version 0.5.0
      conan create all/conanfile.py --version 0.5.0 -o libqasm/*:build_type=Debug