### PR TITLE
tree-gen: add version 1.0.7

### DIFF
--- a/recipes/tree-gen/all/conandata.yml
+++ b/recipes/tree-gen/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.0.7":
     url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.7.tar.gz"
-    sha256: "7978cc5f3c9cd28081bc757126000351029e69070e5091ea758757fed3298d15"
+    sha256: "bd27c88d789efe1d187846d3b819fbaa1ba3a520d6d4181d1216c4a2e73e4e85"
   "1.0.6":
     url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.6.tar.gz"
     sha256: "a7f6617830b3817b21cddc0f4442a04c10fbb89a19cabb1bbd0e8facb040cba8"

--- a/recipes/tree-gen/all/conandata.yml
+++ b/recipes/tree-gen/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.7":
+    url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.7.tar.gz"
+    sha256: "7dde5ef8cbb24588d661feddfc4ee9a77836696867ac85018b7d8d0da9744890"
   "1.0.6":
     url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.6.tar.gz"
     sha256: "a7f6617830b3817b21cddc0f4442a04c10fbb89a19cabb1bbd0e8facb040cba8"

--- a/recipes/tree-gen/all/conandata.yml
+++ b/recipes/tree-gen/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.0.7":
     url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.7.tar.gz"
-    sha256: "7dde5ef8cbb24588d661feddfc4ee9a77836696867ac85018b7d8d0da9744890"
+    sha256: "cddb6d90d25d781e04c28c17d3d2c7b00c3b15e46573bdfdaeabe2f358e35453"
   "1.0.6":
     url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.6.tar.gz"
     sha256: "a7f6617830b3817b21cddc0f4442a04c10fbb89a19cabb1bbd0e8facb040cba8"

--- a/recipes/tree-gen/all/conandata.yml
+++ b/recipes/tree-gen/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.0.7":
     url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.7.tar.gz"
-    sha256: "cddb6d90d25d781e04c28c17d3d2c7b00c3b15e46573bdfdaeabe2f358e35453"
+    sha256: "7978cc5f3c9cd28081bc757126000351029e69070e5091ea758757fed3298d15"
   "1.0.6":
     url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.6.tar.gz"
     sha256: "a7f6617830b3817b21cddc0f4442a04c10fbb89a19cabb1bbd0e8facb040cba8"

--- a/recipes/tree-gen/config.yml
+++ b/recipes/tree-gen/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.0.7":
+    folder: all
   "1.0.6":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **tree-gen/1.0.7**

Bump version to 1.0.7.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
