### PR TITLE
tree-gen: add version 1.0.8

### DIFF
--- a/recipes/tree-gen/all/conandata.yml
+++ b/recipes/tree-gen/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.8":
+    url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.8.tar.gz"
+    sha256: "85539188350b8a4aebba538f6a51ea7a841ebdfb6d04fa9cc3b96612820d25f5"
   "1.0.7":
     url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.7.tar.gz"
     sha256: "bd27c88d789efe1d187846d3b819fbaa1ba3a520d6d4181d1216c4a2e73e4e85"

--- a/recipes/tree-gen/all/conandata.yml
+++ b/recipes/tree-gen/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.0.8":
     url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.8.tar.gz"
-    sha256: "85539188350b8a4aebba538f6a51ea7a841ebdfb6d04fa9cc3b96612820d25f5"
+    sha256: "a840f1da2fa377d2d791885d83b95dc15f081b308208d3497c395721488a4130"
   "1.0.7":
     url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.7.tar.gz"
     sha256: "bd27c88d789efe1d187846d3b819fbaa1ba3a520d6d4181d1216c4a2e73e4e85"

--- a/recipes/tree-gen/all/conanfile.py
+++ b/recipes/tree-gen/all/conanfile.py
@@ -76,7 +76,10 @@ class TreeGenConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
 
     def requirements(self):
-        self.requires("fmt/11.0.2", transitive_headers=True)
+        if Version(self.version) < "1.0.8":
+            self.requires("fmt/10.2.1", transitive_headers=True)
+        else:
+            self.requires("fmt/11.0.2", transitive_headers=True)
         self.requires("range-v3/0.12.0", transitive_headers=True)
 
     def source(self):

--- a/recipes/tree-gen/all/conanfile.py
+++ b/recipes/tree-gen/all/conanfile.py
@@ -60,7 +60,7 @@ class TreeGenConan(ConanFile):
 
     def build_requirements(self):
         if self._should_build_test:
-            self.test_requires("gtest/1.14.0")
+            self.test_requires("gtest/1.15.0")
         self.tool_requires("m4/1.4.19")
         if self.settings.os == "Windows":
             self.tool_requires("winflexbison/2.5.24")
@@ -76,7 +76,7 @@ class TreeGenConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
 
     def requirements(self):
-        self.requires("fmt/10.2.1", transitive_headers=True)
+        self.requires("fmt/11.0.2", transitive_headers=True)
         self.requires("range-v3/0.12.0", transitive_headers=True)
 
     def source(self):

--- a/recipes/tree-gen/config.yml
+++ b/recipes/tree-gen/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.8":
+    folder: all
   "1.0.7":
     folder: all
   "1.0.6":


### PR DESCRIPTION
### Summary
Changes to recipe:  **tree-gen/1.0.8**

#### Motivation
Just an update of dependencies.

#### Details
`config.yml` and `conandata.yml` point to the newly created `tree-gen/1.0.8`.
`conanfile.py` updates gtest conan package to 1.15.0 and fmt to 11.0.2.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan